### PR TITLE
Add arg key to inspect specific namespace in k8s cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ spec:
   * Default: `5m`
 * `--ignored-images` — comma-separated list of images to ignore while checking absent images.
 * `--skip-registry-cert-verification` — whether to skip registries' certificate verification.
+* `--namespace` — inspect specific namespace instead of whole k8s cluster.
 
 ## Metrics
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	ignoredImagesStr := flag.String("ignored-images", "", "comma-separated image names to ignore")
 	bindAddr := flag.String("bind-address", ":8080", "address:port to bind /metrics endpoint to")
 	insecureSkipVerify := flag.Bool("skip-registry-cert-verification", false, "whether to skip registries' certificate verification")
+	specificNamespace := flag.String("namespace", "", "inspect specific namespace instead of whole k8s cluster")
 	flag.Parse()
 
 	logrus.SetFormatter(&logrus.TextFormatter{
@@ -64,6 +65,7 @@ func main() {
 		kubeClient,
 		*insecureSkipVerify,
 		strings.Split(*ignoredImagesStr, ","),
+		*specificNamespace,
 	)
 	prometheus.MustRegister(registryChecker)
 

--- a/pkg/registry_checker/checker.go
+++ b/pkg/registry_checker/checker.go
@@ -53,8 +53,12 @@ func NewRegistryChecker(
 	kubeClient *kubernetes.Clientset,
 	skipVerify bool,
 	ignoredImages []string,
+	specificNamespace string,
 ) *RegistryChecker {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, time.Hour)
+	if specificNamespace != "" {
+		informerFactory = informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Hour, informers.WithNamespace(specificNamespace))
+	}
 
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	if skipVerify {


### PR DESCRIPTION
In some cases, inspection of whole cluster might be forbidden and it is possible only to some namespaces. Those changes will help to make it happen.