### PR TITLE
Pull secret from pods and skip checks for controllers having zero replicas

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -13,6 +13,12 @@ rules:
       - watch
       - get
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
       - extensions
       - apps
     resources:

--- a/helm/k8s-image-availability-exporter/templates/rbac.yaml
+++ b/helm/k8s-image-availability-exporter/templates/rbac.yaml
@@ -13,6 +13,12 @@ rules:
       - watch
       - get
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
       - extensions
       - apps
     resources:


### PR DESCRIPTION
- If a particular controller has no`imagePullSecrets` specified try to find that parameter in its Pods.
- Skip checks for controllers that are scaled to zero.
- Run `reconcileUpdate` if an object has been changed.
- Typo fix-up.