### PR TITLE
Pull secret from ServiceAccounts and skip checks for controllers having zero replicas

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -13,6 +13,12 @@ rules:
       - watch
       - get
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
       - extensions
       - apps
     resources:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -15,9 +15,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
+      - serviceaccounts
     verbs:
-      - list
+      - get
   - apiGroups:
       - extensions
       - apps

--- a/helm/k8s-image-availability-exporter/templates/rbac.yaml
+++ b/helm/k8s-image-availability-exporter/templates/rbac.yaml
@@ -13,6 +13,12 @@ rules:
       - watch
       - get
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
       - extensions
       - apps
     resources:

--- a/helm/k8s-image-availability-exporter/templates/rbac.yaml
+++ b/helm/k8s-image-availability-exporter/templates/rbac.yaml
@@ -15,9 +15,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
+      - serviceaccounts
     verbs:
-      - list
+      - get
   - apiGroups:
       - extensions
       - apps


### PR DESCRIPTION
- If a particular controller has no`imagePullSecrets` specified try to find that parameter in its Pods.
- Skip checks for controllers that are scaled to zero.
- Run `reconcileUpdate` if an object has been changed.
- Typo fix-up.